### PR TITLE
fix firebase firestore import

### DIFF
--- a/firestore/swift/firestore-smoketest/AppDelegate.swift
+++ b/firestore/swift/firestore-smoketest/AppDelegate.swift
@@ -17,6 +17,7 @@
 import UIKit
 
 import Firebase
+import FirebaseFirestore
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {


### PR DESCRIPTION
Adds FirebaseFirestore to the example, otherwise an "unresolved identifier 'Firestore'" warning is thrown by Xcode