### PR TITLE
Fix docs: replace "sum type" with "Result type"

### DIFF
--- a/firestore/swift/firestore-smoketest/ViewController.swift
+++ b/firestore/swift/firestore-smoketest/ViewController.swift
@@ -761,7 +761,7 @@ class ViewController: UIViewController {
             // of a value that does not exist.
             //
             // There are thus three cases to handle, which Swift lets us describe
-            // nicely with built-in sum types:
+            // nicely with built-in Result types:
             //
             //      Result
             //        /\


### PR DESCRIPTION
The code uses a Result type to wrap the result of mapping a document. The comment, however, talks about a "sum type". Shouldn't this be "Result type"?