### PR TITLE
SolutionGeoPointViewController: Update compactMap to map

### DIFF
--- a/firestore/swift/firestore-smoketest/SolutionGeoPointViewController.swift
+++ b/firestore/swift/firestore-smoketest/SolutionGeoPointViewController.swift
@@ -65,8 +65,7 @@ class SolutionGeoPointController: UIViewController {
         // depending on overlap, but in most cases there are 4.
         let queryBounds = GFUtils.queryBounds(forLocation: center,
                                               withRadius: radiusInM)
-        let queries = queryBounds.compactMap { (any) -> Query? in
-            guard let bound = any as? GFGeoQueryBounds else { return nil }
+        let queries = queryBounds.map { bound -> Query in
             return db.collection("cities")
                 .order(by: "geohash")
                 .start(at: [bound.startValue])


### PR DESCRIPTION
Since GeoFire doesn't produce Any or Optional<Query> anymore, it is save to use map instead of compactMap. 
Because of this change, the guard unwrapping is also not needed anymore.