### PR TITLE
add ad impression ios objc 270

### DIFF
--- a/firoptions/FiroptionConfiguration.xcodeproj/project.pbxproj
+++ b/firoptions/FiroptionConfiguration.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		8DFC20162410844B004392AD /* AnalyticsHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DFC20152410844B004392AD /* AnalyticsHelper.m */; };
+		A19F764427EDED14002DE108 /* ISImpressionData.m in Sources */ = {isa = PBXBuildFile; fileRef = A19F764027EDED14002DE108 /* ISImpressionData.m */; };
+		A19F764527EDED14002DE108 /* MAAd.m in Sources */ = {isa = PBXBuildFile; fileRef = A19F764327EDED14002DE108 /* MAAd.m */; };
 		EFEC9D631E01BF310021BDF9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFEC9D621E01BF310021BDF9 /* AppDelegate.swift */; };
 		EFEC9D651E01BF310021BDF9 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFEC9D641E01BF310021BDF9 /* ViewController.swift */; };
 		EFEC9D681E01BF310021BDF9 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EFEC9D661E01BF310021BDF9 /* Main.storyboard */; };
@@ -27,6 +29,10 @@
 		8DFC20132410844A004392AD /* FiroptionConfiguration-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FiroptionConfiguration-Bridging-Header.h"; sourceTree = "<group>"; };
 		8DFC20142410844B004392AD /* AnalyticsHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AnalyticsHelper.h; sourceTree = "<group>"; };
 		8DFC20152410844B004392AD /* AnalyticsHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AnalyticsHelper.m; sourceTree = "<group>"; };
+		A19F764027EDED14002DE108 /* ISImpressionData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ISImpressionData.m; sourceTree = "<group>"; };
+		A19F764127EDED14002DE108 /* ISImpressionData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ISImpressionData.h; sourceTree = "<group>"; };
+		A19F764227EDED14002DE108 /* MAAd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MAAd.h; sourceTree = "<group>"; };
+		A19F764327EDED14002DE108 /* MAAd.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MAAd.m; sourceTree = "<group>"; };
 		EFEC9D5F1E01BF310021BDF9 /* FiroptionConfiguration.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FiroptionConfiguration.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EFEC9D621E01BF310021BDF9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		EFEC9D641E01BF310021BDF9 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -93,6 +99,10 @@
 				EFEC9D641E01BF310021BDF9 /* ViewController.swift */,
 				8DFC20142410844B004392AD /* AnalyticsHelper.h */,
 				8DFC20152410844B004392AD /* AnalyticsHelper.m */,
+				A19F764127EDED14002DE108 /* ISImpressionData.h */,
+				A19F764027EDED14002DE108 /* ISImpressionData.m */,
+				A19F764227EDED14002DE108 /* MAAd.h */,
+				A19F764327EDED14002DE108 /* MAAd.m */,
 				EFEC9D661E01BF310021BDF9 /* Main.storyboard */,
 				EFEC9D691E01BF310021BDF9 /* Assets.xcassets */,
 				EFEC9D6B1E01BF310021BDF9 /* LaunchScreen.storyboard */,
@@ -220,6 +230,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A19F764527EDED14002DE108 /* MAAd.m in Sources */,
+				A19F764427EDED14002DE108 /* ISImpressionData.m in Sources */,
 				EFEC9D651E01BF310021BDF9 /* ViewController.swift in Sources */,
 				EFEC9D631E01BF310021BDF9 /* AppDelegate.swift in Sources */,
 				8DFC20162410844B004392AD /* AnalyticsHelper.m in Sources */,

--- a/firoptions/FiroptionConfiguration/AnalyticsHelper.h
+++ b/firoptions/FiroptionConfiguration/AnalyticsHelper.h
@@ -15,11 +15,9 @@
 //
 
 #import <Foundation/Foundation.h>
-
 NS_ASSUME_NONNULL_BEGIN
 
-@interface AnalyticsHelper : NSObject
+@interface AnalyticsHelper: NSObject
 
 @end
-
 NS_ASSUME_NONNULL_END

--- a/firoptions/FiroptionConfiguration/AnalyticsHelper.m
+++ b/firoptions/FiroptionConfiguration/AnalyticsHelper.m
@@ -296,39 +296,31 @@
 
 // MARK: ad_impression
 // Log ad_impression for sharing advertising impression data.
-
 // [START log_ad_impression_applovin]
-- (void)didPayRevenueForAd:(MAAd *)impressionData
-{
-    //double revenue = impressionData.revenue; // In USD
-
+- (void)didPayRevenueForAd:(MAAd *) impressionData {
     [FIRAnalytics logEventWithName:kFIREventAdImpression
-                    parameters:@{
-                        kFIRParameterAdPlatform:@"AppLovin",
-                        kFIRParameterAdSource:impressionData.networkName,
-                        kFIRParameterAdFormat:impressionData.format,
-                        kFIRParameterAdUnitName:impressionData.adUnitIdentifier,
-                        kFIRParameterCurrency:@"USD", // All Applovin revenue is sent in USD
+                    parameters: @{
+                        kFIRParameterAdPlatform: @"AppLovin",
+                        kFIRParameterAdSource: impressionData.networkName,
+                        kFIRParameterAdFormat: impressionData.format,
+                        kFIRParameterAdUnitName: impressionData.adUnitIdentifier,
+                        kFIRParameterCurrency: @"USD", // All Applovin revenue is sent in USD
                         kFIRParameterValue: impressionData.revenue
                     }];
-
 }
 // [END log_ad_impression_applovin]
 
 // [START log_ad_impression_ironsource]
-- (void)impressionDataDidSucceed:(ISImpressionData *)impressionData {
-
-
+- (void)impressionDataDidSucceed: (ISImpressionData *)impressionData {
 [FIRAnalytics logEventWithName:kFIREventAdImpression
                    parameters:@{
-                       kFIRParameterAdPlatform:@"ironSource",
-                       kFIRParameterAdSource:impressionData.ad_network,
-                       kFIRParameterAdFormat:impressionData.ad_unit,
-                       kFIRParameterAdUnitName:impressionData.instance_name,
-                       kFIRParameterCurrency:@"USD",
-                       kFIRParameterValue:impressionData.revenue
+                       kFIRParameterAdPlatform: @"ironSource",
+                       kFIRParameterAdSource: impressionData.ad_network,
+                       kFIRParameterAdFormat: impressionData.ad_unit,
+                       kFIRParameterAdUnitName: impressionData.instance_name,
+                       kFIRParameterCurrency: @"USD",
+                       kFIRParameterValue: impressionData.revenue
                    }];
-
 }
 // [END log_ad_impression_ironsource]
 @end

--- a/firoptions/FiroptionConfiguration/AnalyticsHelper.m
+++ b/firoptions/FiroptionConfiguration/AnalyticsHelper.m
@@ -18,6 +18,10 @@
 
 #import "AnalyticsHelper.h"
 
+// Importing simulated 3rd party ad_impressions to  ensure this project compiles. Not required to implement Firebase ad_impression tracking
+#import "MAAd.h"
+#import "ISImpressionData.h"
+
 @implementation AnalyticsHelper
 
 - (void)logInAppPurchase {
@@ -290,4 +294,41 @@
   // [END apply_promo]
 }
 
+// MARK: ad_impression
+// Log ad_impression for sharing advertising impression data.
+
+// [START log_ad_impression_applovin]
+- (void)didPayRevenueForAd:(MAAd *)impressionData
+{
+    //double revenue = impressionData.revenue; // In USD
+
+    [FIRAnalytics logEventWithName:kFIREventAdImpression
+                    parameters:@{
+                        kFIRParameterAdPlatform:@"AppLovin",
+                        kFIRParameterAdSource:impressionData.networkName,
+                        kFIRParameterAdFormat:impressionData.format,
+                        kFIRParameterAdUnitName:impressionData.adUnitIdentifier,
+                        kFIRParameterCurrency:@"USD", // All Applovin revenue is sent in USD
+                        kFIRParameterValue: impressionData.revenue
+                    }];
+
+}
+// [END log_ad_impression_applovin]
+
+// [START log_ad_impression_ironsource]
+- (void)impressionDataDidSucceed:(ISImpressionData *)impressionData {
+
+
+[FIRAnalytics logEventWithName:kFIREventAdImpression
+                   parameters:@{
+                       kFIRParameterAdPlatform:@"ironSource",
+                       kFIRParameterAdSource:impressionData.ad_network,
+                       kFIRParameterAdFormat:impressionData.ad_unit,
+                       kFIRParameterAdUnitName:impressionData.instance_name,
+                       kFIRParameterCurrency:@"USD",
+                       kFIRParameterValue:impressionData.revenue
+                   }];
+
+}
+// [END log_ad_impression_ironsource]
 @end

--- a/firoptions/FiroptionConfiguration/ISImpressionData.h
+++ b/firoptions/FiroptionConfiguration/ISImpressionData.h
@@ -1,0 +1,29 @@
+//
+//  Copyright (c) 2020 Google Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+#import <Foundation/Foundation.h>
+
+@interface ISImpressionData:NSObject
+// Simulated ad_impression structures from mediation platforms to ensure that this project compiles.
+
+// Ironsource Sample Publisher Ad Impression
+@property (nonatomic, strong)NSString *ad_network;
+@property (nonatomic, strong)NSString *ad_unit;
+@property (nonatomic, strong)NSString *instance_name;
+@property (nonatomic) NSNumber *revenue;
+
+@end
+
+

--- a/firoptions/FiroptionConfiguration/ISImpressionData.h
+++ b/firoptions/FiroptionConfiguration/ISImpressionData.h
@@ -15,15 +15,12 @@
 //
 #import <Foundation/Foundation.h>
 
-@interface ISImpressionData:NSObject
+@interface ISImpressionData: NSObject
 // Simulated ad_impression structures from mediation platforms to ensure that this project compiles.
-
 // Ironsource Sample Publisher Ad Impression
-@property (nonatomic, strong)NSString *ad_network;
-@property (nonatomic, strong)NSString *ad_unit;
-@property (nonatomic, strong)NSString *instance_name;
+@property (nonatomic, strong) NSString *ad_network;
+@property (nonatomic, strong) NSString *ad_unit;
+@property (nonatomic, strong) NSString *instance_name;
 @property (nonatomic) NSNumber *revenue;
 
 @end
-
-

--- a/firoptions/FiroptionConfiguration/ISImpressionData.m
+++ b/firoptions/FiroptionConfiguration/ISImpressionData.m
@@ -1,0 +1,24 @@
+//
+//  Copyright (c) 2020 Google Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+#import "ISImpressionData.h"
+// Simulated ad_impression structures from mediation platforms to ensure that this project compiles
+
+// Ironsource Sample Publisher Ad Impression
+@implementation ISImpressionData
+
+@end

--- a/firoptions/FiroptionConfiguration/ISImpressionData.m
+++ b/firoptions/FiroptionConfiguration/ISImpressionData.m
@@ -17,7 +17,6 @@
 #import <Foundation/Foundation.h>
 #import "ISImpressionData.h"
 // Simulated ad_impression structures from mediation platforms to ensure that this project compiles
-
 // Ironsource Sample Publisher Ad Impression
 @implementation ISImpressionData
 

--- a/firoptions/FiroptionConfiguration/MAAd.h
+++ b/firoptions/FiroptionConfiguration/MAAd.h
@@ -17,14 +17,10 @@
 
 @interface MAAd:NSObject
 // Simulated ad_impression structures from mediation platforms to ensure that this project compiles
-
 // AppLovin Sample Publisher Ad Impression
-@property (nonatomic, strong)NSString *adUnitIdentifier;
-@property (nonatomic, strong)NSString *networkName;
-@property (nonatomic, strong)NSString *format;
+@property (nonatomic, strong) NSString *adUnitIdentifier;
+@property (nonatomic, strong) NSString *networkName;
+@property (nonatomic, strong) NSString *format;
 @property (nonatomic) NSNumber *revenue;
 
-
 @end
-
-

--- a/firoptions/FiroptionConfiguration/MAAd.h
+++ b/firoptions/FiroptionConfiguration/MAAd.h
@@ -1,0 +1,30 @@
+//
+//  Copyright (c) 2020 Google Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+#import <Foundation/Foundation.h>
+
+@interface MAAd:NSObject
+// Simulated ad_impression structures from mediation platforms to ensure that this project compiles
+
+// AppLovin Sample Publisher Ad Impression
+@property (nonatomic, strong)NSString *adUnitIdentifier;
+@property (nonatomic, strong)NSString *networkName;
+@property (nonatomic, strong)NSString *format;
+@property (nonatomic) NSNumber *revenue;
+
+
+@end
+
+

--- a/firoptions/FiroptionConfiguration/MAAd.m
+++ b/firoptions/FiroptionConfiguration/MAAd.m
@@ -1,0 +1,22 @@
+//
+//  Copyright (c) 2020 Google Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+#import "MAAd.h"
+// Simulated ad_impression structures from mediation platforms to ensure that this project compiles
+@implementation MAAd
+
+@end

--- a/firoptions/FiroptionConfiguration/ViewController.swift
+++ b/firoptions/FiroptionConfiguration/ViewController.swift
@@ -341,6 +341,7 @@ class ViewController: UIViewController {
     }
   }
   // [END log_ad_impression_mopub]
+    
   // [START log_ad_impression_ironsource]
   func impressionDataDidSucceed(_ impressionData: ISImpressionData!) {
     Analytics.logEvent(
@@ -355,6 +356,7 @@ class ViewController: UIViewController {
       ])
   }
   // [END log_ad_impression_ironsource]
+
   // [START log_ad_impression_applovin]
   func didPayRevenue(_ impressionData: MAAd?) {
     if let impressionData = impressionData {


### PR DESCRIPTION
This PR adds the snippets for `ad_impression` for ObjC to complete fix for #270 
I simulated the 3rd party ad impressions using custom classes to reduce reliance on 3rd party libraries and to make it consistent with Swift snippets