### PR TITLE
Remove unnecessary semicolons

### DIFF
--- a/firestore/swift/firestore-smoketest/ViewController.swift
+++ b/firestore/swift/firestore-smoketest/ViewController.swift
@@ -1095,7 +1095,7 @@ class ViewController: UIViewController {
         // [END in_filter]
 
         // [START in_filter_with_array]
-        citiesRef.whereField("regions", in: [["west_coast"], ["east_coast"]]);
+        citiesRef.whereField("regions", in: [["west_coast"], ["east_coast"]])
         // [END in_filter_with_array]
 
         // [START not_in_filter]
@@ -1288,7 +1288,7 @@ class ViewController: UIViewController {
             let snapshot = try await countQuery.getAggregation(source: .server)
             print(snapshot.count)
         } catch {
-            print(error);
+            print(error)
         }
         // [END count_aggregate_collection]
     }
@@ -1301,7 +1301,7 @@ class ViewController: UIViewController {
             let snapshot = try await countQuery.getAggregation(source: .server)
             print(snapshot.count)
         } catch {
-            print(error);
+            print(error)
         }
         // [END count_aggregate_query]
     }


### PR DESCRIPTION
According to Google's Swift Style Guide,

Semicolons (;) are not used, either to terminate or separate statements.
In other words, the only location where a semicolon may appear is inside a string literal or a comment.