### PR TITLE
Update Vertex AI xcodeproj to use `firebase-ios-sdk` `main` branch

### DIFF
--- a/vertexai/VertexAISnippets.xcodeproj/project.pbxproj
+++ b/vertexai/VertexAISnippets.xcodeproj/project.pbxproj
@@ -384,7 +384,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
 			requirement = {
-				branch = "vertexai-preview-0.1.0";
+				branch = main;
 				kind = branch;
 			};
 		};


### PR DESCRIPTION
Updated the `firebase-ios-sdk` Swift package dependency in the Vertex AI Xcode project to use the `main` branch instead of `vertexai-preview-0.1.0` (no longer updated).